### PR TITLE
RFC: Make app respect system theme

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -3,57 +3,44 @@ import 'package:flutter/material.dart';
 class Constants {
   static String appName = 'GnuCash Mobile';
 
-  static Color lightPrimary = Color(0xfff3f4f9);
-  static Color darkPrimary = Color(0xff2B2B2B);
-  static Color lightAccent = Color(0xff597ef7);
-  static Color darkAccent = Color(0xff597ef7);
-  static Color lightBG = Color(0xfff3f4f9);
-  static Color darkBG = Color(0xff2B2B2B);
+  // Colors
+  static Color white = Color(0xfff3f4f9);
+  static Color black = Color(0xff1B1B1B);
+  static Color mutedBlack = Color(0xff2B2B2B);
+  static Color blue = Color(0xff597ef7);
+  static Color mutedBlue = Color(0xff597ef7);
+  static Color red = Color(0xffc11c1c);
+  static Color mutedRed = Color(0xffc94848);
+  static Color green = Color(0xff76c759);
+  static Color mutedGreen = Color(0xff589244);
 
   static TextStyle biggerFont = TextStyle(fontSize: 18.0);
 
   static ThemeData lightTheme = ThemeData(
-    backgroundColor: lightBG,
-    primaryColor: lightPrimary,
-    accentColor: lightAccent,
-    scaffoldBackgroundColor: lightBG,
-    appBarTheme: AppBarTheme(
-      elevation: 0,
-      textTheme: TextTheme(
-        headline6: TextStyle(
-          color: Colors.black,
-          fontSize: 20,
-          fontWeight: FontWeight.w800,
-        ),
-      ),
-    ),
+    colorScheme: ColorScheme.light().copyWith(
+      background: white,
+      onBackground: black,
+      brightness: Brightness.light,
+      primary: green,
+      onPrimary: black,
+      secondary: blue,
+      onSecondary: white,
+      error: red,
+      onError: white,
+    )
   );
 
   static ThemeData darkTheme = ThemeData(
-    brightness: Brightness.dark,
-    backgroundColor: darkBG,
-    primaryColor: darkPrimary,
-    accentColor: darkAccent,
-    scaffoldBackgroundColor: darkBG,
-    appBarTheme: AppBarTheme(
-      backgroundColor: darkBG,
-      elevation: 0,
-      textTheme: TextTheme(
-        headline6: TextStyle(
-          color: lightBG,
-          fontSize: 20,
-          fontWeight: FontWeight.w800,
-        ),
-      ),
-    ),
+    colorScheme: ColorScheme.dark().copyWith(
+      primary: mutedGreen,
+      onPrimary: white,
+      secondary: mutedBlue,
+      onSecondary: white,
+      error: mutedRed,
+      onError: white,
+      background: mutedBlack,
+      onBackground: white,
+      brightness: Brightness.dark,
+    )
   );
-
-  // static List<T> map<T>(List list, Function handler) {
-  //   List<T> result = [];
-  //   for (var i = 0; i < list.length; i++) {
-  //     result.add(handler(i, list[i]));
-  //   }
-  //
-  //   return result;
-  // }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,8 +30,30 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: Constants.appName,
-      theme: Constants.lightTheme,
-      darkTheme: Constants.darkTheme,
+      theme: Constants.lightTheme.copyWith(
+        scaffoldBackgroundColor: Constants.lightTheme.colorScheme.background,
+        appBarTheme: AppBarTheme(
+          backgroundColor: Constants.lightTheme.colorScheme.primary,
+          elevation: 0,
+          titleTextStyle: TextStyle(
+            color: Constants.lightTheme.colorScheme.onPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ),
+      darkTheme: Constants.darkTheme.copyWith(
+        scaffoldBackgroundColor: Constants.darkTheme.colorScheme.background,
+        appBarTheme: AppBarTheme(
+          backgroundColor: Constants.darkTheme.colorScheme.primary,
+          elevation: 0,
+          titleTextStyle: TextStyle(
+            color: Constants.darkTheme.colorScheme.onPrimary,
+            fontSize: 20,
+            fontWeight: FontWeight.w800,
+          ),
+        ),
+      ),
       home: MyHomePage(title: 'Accounts'),
       supportedLocales: numberFormatSymbols.keys
           .where((key) => key.toString().contains('_'))
@@ -70,7 +92,6 @@ class _MyHomePageState extends State<MyHomePage> {
 
             return Scaffold(
               appBar: AppBar(
-                backgroundColor: Constants.darkBG,
                 title: Text(widget.title),
               ),
               body: _hasImported ? ListOfAccounts(accounts: accounts) : Intro(),
@@ -82,12 +103,11 @@ class _MyHomePageState extends State<MyHomePage> {
                     child: Text(
                       "GnuCash Mobile",
                       style: TextStyle(
-                        color: Constants.lightPrimary,
                         fontSize: 20,
                       ),
                     ),
                     decoration: BoxDecoration(
-                      color: Constants.darkBG,
+                      color: Theme.of(context).colorScheme.primary,
                     ),
                   ),
                   ListTile(
@@ -190,7 +210,7 @@ class _MyHomePageState extends State<MyHomePage> {
               floatingActionButton: _hasImported
                   ? Builder(builder: (context) {
                       return FloatingActionButton(
-                        backgroundColor: Constants.darkBG,
+                        backgroundColor: Theme.of(context).colorScheme.primary,
                         child: Icon(Icons.add),
                         onPressed: () async {
                           final _success = await Navigator.push(

--- a/lib/widgets/account_view.dart
+++ b/lib/widgets/account_view.dart
@@ -6,8 +6,6 @@ import 'package:gnucash_mobile/widgets/transaction_form.dart';
 import 'package:gnucash_mobile/widgets/transactions_view.dart';
 import 'package:provider/provider.dart';
 
-import '../constants.dart';
-
 class AccountView extends StatelessWidget {
   final Account account;
 
@@ -19,13 +17,13 @@ class AccountView extends StatelessWidget {
     if (this.account.placeholder) {
       return Scaffold(
         appBar: AppBar(
-          backgroundColor: Constants.darkBG,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           title: Text(this.account.fullName),
         ),
         body: ListOfAccounts(accounts: this.account.children),
         floatingActionButton: Builder(builder: (context) {
           return FloatingActionButton(
-            backgroundColor: Constants.darkBG,
+            backgroundColor: Theme.of(context).colorScheme.primary,
             child: Icon(Icons.add),
             onPressed: () async {
               final _success = await Navigator.push(
@@ -70,7 +68,7 @@ class AccountView extends StatelessWidget {
         ),
         floatingActionButton: Builder(builder: (context) {
           return FloatingActionButton(
-            backgroundColor: Constants.darkBG,
+            backgroundColor: Theme.of(context).colorScheme.primary,
             child: Icon(Icons.add),
             onPressed: () async {
               final _success = await Navigator.push(

--- a/lib/widgets/export.dart
+++ b/lib/widgets/export.dart
@@ -9,8 +9,6 @@ import 'package:intl/intl.dart';
 import 'package:path_provider/path_provider.dart';
 import 'package:provider/provider.dart';
 
-import '../constants.dart';
-
 class Export extends StatefulWidget {
   @override
   _ExportState createState() => _ExportState();
@@ -84,10 +82,10 @@ class _ExportState extends State<Export> {
                   //   "Export to: $_folder"
                   // ),
                   // FlatButton(
-                  //   color: Constants.darkAccent,
+                  //   color: Constants.mutedBlue,
                   //   onPressed: () => _selectFolder(),
                   //   child: Text("Pick folder"),
-                  //   textColor: Constants.lightPrimary,
+                  //   textColor: Theme.of(context).colorScheme.onPrimary,
                   // ),
                   CheckboxListTile(
                     contentPadding:
@@ -103,7 +101,7 @@ class _ExportState extends State<Export> {
                   TextButton(
                     style: ButtonStyle(
                       backgroundColor: MaterialStateProperty.all<Color>(
-                          Constants.darkAccent),
+                          Theme.of(context).colorScheme.primary),
                     ),
                     onPressed: () async {
                       // if (_directoryPath == null) {
@@ -113,8 +111,8 @@ class _ExportState extends State<Export> {
                       // }
 
                       if (!snapshot.hasData) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                            SnackBar(content: Text("No transactions to export.")));
+                        ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                            content: Text("No transactions to export.")));
                         return;
                       }
 
@@ -140,7 +138,7 @@ class _ExportState extends State<Export> {
                     child: Text(
                       "Export",
                       style: TextStyle(
-                        color: Constants.lightPrimary,
+                        color: Theme.of(context).colorScheme.onPrimary,
                       ),
                     ),
                   ),

--- a/lib/widgets/favorites.dart
+++ b/lib/widgets/favorites.dart
@@ -2,15 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:gnucash_mobile/providers/accounts.dart';
 import 'package:provider/provider.dart';
 
-import '../constants.dart';
-
 class Favorites extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Consumer<AccountsModel>(builder: (context, accounts, child) {
       return Scaffold(
         appBar: AppBar(
-          backgroundColor: Constants.darkBG,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           title: Text("Favorites"),
         ),
         body: Padding(
@@ -79,8 +77,8 @@ class Favorites extends StatelessWidget {
                 ),
                 TextButton(
                   style: ButtonStyle(
-                    backgroundColor:
-                        MaterialStateProperty.all<Color>(Constants.darkAccent),
+                    backgroundColor: MaterialStateProperty.all<Color>(
+                        Theme.of(context).colorScheme.primary),
                   ),
                   onPressed: () {
                     accounts.removeFavoriteDebitAccount();
@@ -88,14 +86,14 @@ class Favorites extends StatelessWidget {
                   child: Text(
                     "Clear favorite debit account",
                     style: TextStyle(
-                      color: Constants.lightPrimary,
+                      color: Theme.of(context).colorScheme.onPrimary,
                     ),
                   ),
                 ),
                 TextButton(
                   style: ButtonStyle(
-                    backgroundColor:
-                        MaterialStateProperty.all<Color>(Constants.darkAccent),
+                    backgroundColor: MaterialStateProperty.all<Color>(
+                        Theme.of(context).colorScheme.primary),
                   ),
                   onPressed: () {
                     accounts.removeFavoriteCreditAccount();
@@ -103,7 +101,7 @@ class Favorites extends StatelessWidget {
                   child: Text(
                     "Clear favorite credit account",
                     style: TextStyle(
-                      color: Constants.lightPrimary,
+                      color: Theme.of(context).colorScheme.onPrimary,
                     ),
                   ),
                 ),

--- a/lib/widgets/intro.dart
+++ b/lib/widgets/intro.dart
@@ -2,7 +2,6 @@ import 'dart:io';
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
-import 'package:gnucash_mobile/constants.dart';
 import 'package:gnucash_mobile/providers/accounts.dart';
 import 'package:provider/provider.dart';
 
@@ -12,12 +11,11 @@ class Intro extends StatelessWidget {
     return Center(
       child: TextButton(
         style: ButtonStyle(
-          backgroundColor:
-              MaterialStateProperty.all<Color>(Constants.darkAccent),
+          backgroundColor: MaterialStateProperty.all<Color>(
+              Theme.of(context).colorScheme.primary),
         ),
         onPressed: () async {
           FilePickerResult result = await FilePicker.platform.pickFiles();
-
           if (result != null) {
             try {
               final _file = File(result.files.single.path);
@@ -36,7 +34,7 @@ class Intro extends StatelessWidget {
         child: Text(
           "Import",
           style: TextStyle(
-            color: Constants.lightPrimary,
+            color: Theme.of(context).colorScheme.onPrimary,
           ),
         ),
       ),

--- a/lib/widgets/list_of_accounts.dart
+++ b/lib/widgets/list_of_accounts.dart
@@ -62,7 +62,7 @@ class ListOfAccounts extends StatelessWidget {
                     MaterialPageRoute(builder: (context) {
                       return Scaffold(
                         appBar: AppBar(
-                          backgroundColor: Constants.darkBG,
+                          backgroundColor: Theme.of(context).colorScheme.primary,
                           title: Text(_account.fullName),
                         ),
                         body: TransactionsView(
@@ -74,7 +74,7 @@ class ListOfAccounts extends StatelessWidget {
                                 []),
                         floatingActionButton: Builder(builder: (context) {
                           return FloatingActionButton(
-                            backgroundColor: Constants.darkBG,
+                            backgroundColor: Theme.of(context).colorScheme.primary,
                             child: Icon(Icons.add),
                             onPressed: () async {
                               final _success = await Navigator.push(

--- a/lib/widgets/transaction_form.dart
+++ b/lib/widgets/transaction_form.dart
@@ -5,8 +5,6 @@ import 'package:gnucash_mobile/providers/transactions.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
-import '../constants.dart';
-
 class TransactionForm extends StatefulWidget {
   final Account toAccount;
 
@@ -44,7 +42,7 @@ class _TransactionFormState extends State<TransactionForm> {
     return Consumer<AccountsModel>(builder: (context, accounts, child) {
       return Scaffold(
         appBar: AppBar(
-          backgroundColor: Constants.darkBG,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           title: Text("New transaction"),
           leading: Builder(builder: (context) {
             return IconButton(
@@ -238,7 +236,7 @@ class _TransactionFormState extends State<TransactionForm> {
         floatingActionButton:
             // Builder(builder: (context) {
             FloatingActionButton(
-          backgroundColor: Constants.darkBG,
+          backgroundColor: Theme.of(context).colorScheme.primary,
           child: Icon(Icons.save_sharp),
           onPressed: () {
             // Validate will return true if the form is valid, or false if

--- a/lib/widgets/transactions_view.dart
+++ b/lib/widgets/transactions_view.dart
@@ -30,7 +30,7 @@ class TransactionsView extends StatelessWidget {
           final _simpleCurrencyValue = _simpleCurrencyNumberFormat
               .format(_simpleCurrencyNumberFormat.parse(_transaction.amount.toString()));
           return Dismissible(
-            background: Container(color: Colors.red),
+            background: Container(color: Theme.of(context).colorScheme.error),
             key: Key(_transaction.description + _transaction.fullAccountName),
             onDismissed: (direction) async {
               transactions.remove(_transaction);


### PR DESCRIPTION
The app currently does not respect system theme toggles. I thought this PR could fix that. Please feel free to make changes and I am happy to take feedback

I have made some changes to constants.dart to help with this work. This initially started with having to remove deprecated `accentColor` to `colorScheme.secondary`.

I have made it easy for us to use implement theming by using this `Theme.of(context).colorScheme.primary`
I decided to go with green rather than the default blue as primary color to keep the spirit of GnuCash Green going

Here are some screenshots
<p>
<img src="https://user-images.githubusercontent.com/24451176/152680484-540610d3-b65d-4ed2-b6d1-651009980eef.png" height = 500/>
<img src="https://user-images.githubusercontent.com/24451176/152680485-1392feae-ae06-4ef1-aaad-8eae0143822e.png" height = 500/>
<img src="https://user-images.githubusercontent.com/24451176/152680486-74db9a5b-817b-485a-96c1-445e0e86296b.png" height = 500/>
<img src="https://user-images.githubusercontent.com/24451176/152680487-922fc574-e850-4478-a63b-0283d7a449a7.png" height = 500/>
</p>