### PR TITLE
Fix format conversion inside transaction view

### DIFF
--- a/lib/widgets/transactions_view.dart
+++ b/lib/widgets/transactions_view.dart
@@ -27,8 +27,8 @@ class TransactionsView extends StatelessWidget {
           }
 
           final _transaction = this.transactions[i];
-          final _simpleCurrencyValue = _simpleCurrencyNumberFormat
-              .format(_simpleCurrencyNumberFormat.parse(_transaction.amount.toString()));
+          final _simpleCurrencyValue =
+              _simpleCurrencyNumberFormat.format(_transaction.amount);
           return Dismissible(
             background: Container(color: Colors.red),
             key: Key(_transaction.description + _transaction.fullAccountName),


### PR DESCRIPTION
Fixes a missed conversion from #14 which would cause a FormatException when Navigating to the Transaction inside the account tree.